### PR TITLE
Added selective dmg/zip packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start": "ENV=DEV electron-forge start",
     "package": "electron-forge package --platform=darwin --arch=x64",
     "make": "electron-forge make",
+    "makedmg": "electron-forge make --targets dmg",
+    "makezip": "electron-forge make --targets zip",
     "icns": "cd ./src/images/icon && ./png2icns.sh icon.png"
   },
   "repository": "https://github.com/will-stone/browserosaurus",
@@ -44,7 +46,7 @@
     "forge": {
       "make_targets": {
         "win32": ["squirrel"],
-        "darwin": ["zip"],
+        "darwin": ["dmg", "zip"],
         "linux": ["deb", "rpm"]
       },
       "electronPackagerConfig": {


### PR DESCRIPTION
#10 

When both modes are used:
<img width="565" alt="schermata 2017-11-15 alle 17 50 22" src="https://user-images.githubusercontent.com/6209647/32849196-c4f2da86-ca2e-11e7-9212-f91e21d435a9.png">

The (very little) improment is that this way is (very little) more user friendly than with the zip files.
You also get ~2Mb for free.

<img width="669" alt="schermata 2017-11-15 alle 17 50 44" src="https://user-images.githubusercontent.com/6209647/32849308-0d3836d8-ca2f-11e7-97e2-e7a56bf5393d.png">

You can also upload both of them on the release page.
