### PR TITLE
feat: move version number to tray

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -134,12 +134,18 @@ app.on('ready', async () => {
       submenu: [{ label: 'Loading...' }],
     },
     {
-      label: 'About',
-      click: app.showAboutPanel,
+      type: 'separator',
     },
     {
       label: 'Quit',
-      click: app.exit,
+      click: () => app.exit(),
+    },
+    {
+      type: 'separator',
+    },
+    {
+      label: 'v' + app.getVersion(),
+      enabled: false,
     },
   ]
   tray.setContextMenu(Menu.buildFromTemplate(contextMenu))


### PR DESCRIPTION
Stop using About window (which is buggy) and just report version number in the tray menu. Also separate options, actions, and info by separators.

The by-product of this is that it fixes #103.