### PR TITLE
fix #108 selecting chrome opening chrome in Parallels

### DIFF
--- a/src/config/activities.ts
+++ b/src/config/activities.ts
@@ -110,7 +110,7 @@ export const activities: Activities = {
   'Google Chrome': {
     name: 'Google Chrome',
     appId: 'Google Chrome',
-    cmd: 'open "{URL}" -a "Google Chrome"',
+    cmd: 'open "{URL}" -a "Google Chrome" -b "com.google.Chrome"',
     hotKey: 'g',
     logo: chrome,
   },


### PR DESCRIPTION
This aims to fix #108 by specifying the application bundle identifier "com.google.Chrome" in the `open` command after selecting Google Chrome. 

Have tested the change with `yarn start` and it seems to fix the issue.

I encounter similar issues as mentioned, but did not want to [disable sharing Windows Applications](https://github.com/facebook/react-native/issues/11480#issuecomment-307465821) nor rename `~/Applications (Parallels)/${Parallels VM Name} Applications/Google Chrome.app`. 

A possible cause is [detailed here](https://stackoverflow.com/a/28484491), where `open` attempts to find the Chrome app from `~/Applications` before searching the folder `/Applications`.

Another way to fix this would be to specify the full path of the application.

Perhaps a longer term solution would be to consider the bundle identifiers for all browsers when listing applications, rather than just the app name.