### PR TITLE
fix(#125): Icon in dock doesn't hide

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -121,6 +121,7 @@ ipcMain.on(CLOSE_WINDOW, () => {
   urlToOpen = undefined
   pickerWindow.hide()
   app.hide()
+  app.dock.hide()
 })
 
 ipcMain.on(OPT_TOGGLE, (_: Event, toggle: boolean) => {


### PR DESCRIPTION
Icon still appears in dock, but it hides right after window is closed.
#125 