### PR TITLE
feat: add official Twitter app from macOS AppStore

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -173,6 +173,9 @@ export const apps = typeApps({
   'org.torproject.torbrowser': {
     name: 'Tor',
   },
+  'maccatalyst.com.atebits.Tweetie2': {
+    name: 'Twitter',
+  },
   'com.vivaldi.Vivaldi': {
     name: 'Vivaldi',
   },


### PR DESCRIPTION
Just add the [official Twitter app from macOS AppStore](https://apps.apple.com/jp/app/twitter/id1482454543?l=en&mt=12)