### PR TITLE
feat: add logging around getAppIcon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "browserosaurus",
-      "version": "18.2.0",
+      "version": "18.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@heroicons/react": "^1.0.6",
@@ -14,6 +14,7 @@
         "app-exists": "^2.1.1",
         "axios": "^0.27.2",
         "clsx": "^1.1.1",
+        "electron-log": "^4.4.7",
         "fast-deep-equal": "^3.1.3",
         "file-icon": "^5.1.0",
         "immer": "^9.0.14",
@@ -5947,6 +5948,11 @@
       "engines": {
         "node": ">= 8.6"
       }
+    },
+    "node_modules/electron-log": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.7.tgz",
+      "integrity": "sha512-uFZQdgevOp9Fn5lDOrJMU/bmmYxDLZitbIHJM7VXN+cpB59ZnPt1FQL4bOf/Dl2gaIMPYJEfXx38GvJma5iV6A=="
     },
     "node_modules/electron-notarize": {
       "version": "1.2.1",
@@ -21926,6 +21932,11 @@
           "dev": true
         }
       }
+    },
+    "electron-log": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.7.tgz",
+      "integrity": "sha512-uFZQdgevOp9Fn5lDOrJMU/bmmYxDLZitbIHJM7VXN+cpB59ZnPt1FQL4bOf/Dl2gaIMPYJEfXx38GvJma5iV6A=="
     },
     "electron-notarize": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "app-exists": "^2.1.1",
     "axios": "^0.27.2",
     "clsx": "^1.1.1",
+    "electron-log": "^4.4.7",
     "fast-deep-equal": "^3.1.3",
     "file-icon": "^5.1.0",
     "immer": "^9.0.14",

--- a/src/main/utils/get-app-icons.ts
+++ b/src/main/utils/get-app-icons.ts
@@ -1,5 +1,5 @@
-// @ts-expect-error -- no types provided for file-icon
 import log from 'electron-log'
+// @ts-expect-error -- no types provided for file-icon
 import { fileIconToBuffer } from 'file-icon'
 
 import type { AppId } from '../../config/apps'
@@ -14,6 +14,7 @@ async function getAppIcon(bundleId: string): Promise<string> {
     return `data:image/png;base64,${buffer.toString('base64')}`
   } catch (error: unknown) {
     log.error(error)
+    // eslint-disable-next-line no-console
     console.error('[getAppIcon error]', error)
     return ''
   }

--- a/src/main/utils/get-app-icons.ts
+++ b/src/main/utils/get-app-icons.ts
@@ -1,4 +1,5 @@
 // @ts-expect-error -- no types provided for file-icon
+import log from 'electron-log'
 import { fileIconToBuffer } from 'file-icon'
 
 import type { AppId } from '../../config/apps'
@@ -8,9 +9,12 @@ import { dispatch } from '../state/store'
 
 async function getAppIcon(bundleId: string): Promise<string> {
   try {
+    log.info('Getting icon from ID', bundleId)
     const buffer = await fileIconToBuffer(bundleId, { size: 64 })
     return `data:image/png;base64,${buffer.toString('base64')}`
-  } catch {
+  } catch (error: unknown) {
+    log.error(error)
+    console.error('[getAppIcon error]', error)
     return ''
   }
 }


### PR DESCRIPTION
Uses `electron-log` to log (in prouction) when `file-icon` is used to get an icon, and when it fails. Output logs will be stored in `~/Library/Logs/Browserosaurus`