### PR TITLE
feat: added support for HomeBrew-installed Librewolf

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -95,6 +95,10 @@ export const apps = typeApps({
   'io.gitlab.librewolf-community.librewolf': {
     name: 'Librewolf',
   },
+  'org.mozilla.librewolf': {
+    name: 'Librewolf',
+    privateArg: '--private-window',
+  },
   'com.linear': {
     name: 'Linear',
   },


### PR DESCRIPTION
When installed via HomeBrew, Librewolf's bundle identifier is org.mozilla.librewolf.