### PR TITLE
feat: add support for Whist browser

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -198,6 +198,9 @@ const apps = typeApps({
     name: 'Wavebox',
     privateArg: '--incognito',
   },
+  'com.whisttechnologies.whist': {
+    name: 'Whist',
+  },
   'ru.yandex.desktop.yandex-browser': {
     name: 'Yandex',
   },


### PR DESCRIPTION
I have tested Browserosaurus with Whist locally and it behaves as I'd expect.