### PR TITLE
Fix for inconsistent detection of apps when Spotlight index is not ready

### DIFF
--- a/src/main/utils/get-installed-app-ids.ts
+++ b/src/main/utils/get-installed-app-ids.ts
@@ -55,9 +55,9 @@ async function getAllInstalledApps(): Promise<string[]> {
       '-iname',
       '*.app',
       '-prune',
-      '-o',
-      '-iname',
-      '*.app',
+      '-not',
+      '-path',
+      '*/.*',
     ]
   } else {
     findArguments = [
@@ -65,9 +65,9 @@ async function getAllInstalledApps(): Promise<string[]> {
       '-iname',
       '*.app',
       '-prune',
-      '-o',
-      '-iname',
-      '*.app',
+      '-not',
+      '-path',
+      '*/.*',
     ]
   }
 

--- a/src/main/utils/get-installed-app-ids.ts
+++ b/src/main/utils/get-installed-app-ids.ts
@@ -54,11 +54,21 @@ async function getAllInstalledApps(): Promise<string[]> {
       path.join(homedir(), 'Applications'),
       '-iname',
       '*.app',
-      '-maxdepth',
-      '1',
+      '-prune',
+      '-o',
+      '-iname',
+      '*.app',
     ]
   } else {
-    findArguments = ['/Applications', '-iname', '*.app', '-maxdepth', '1']
+    findArguments = [
+      '/Applications',
+      '-iname',
+      '*.app',
+      '-prune',
+      '-o',
+      '-iname',
+      '*.app',
+    ]
   }
 
   const { stdout: allApps } = await execFileP('find', findArguments)

--- a/src/main/utils/get-installed-app-ids.ts
+++ b/src/main/utils/get-installed-app-ids.ts
@@ -19,7 +19,7 @@ async function getAllInstalledAppBundleIds(): Promise<[string[], string[]]> {
     '/Applications',
     '-onlyin',
     path.join(homedir(), 'Applications'),
-    "kMDItemKind == '*'",
+    'kind:app',
     '-attr',
     'kMDItemCFBundleIdentifier',
   ])
@@ -34,7 +34,7 @@ async function getAllInstalledAppBundleIds(): Promise<[string[], string[]]> {
     if (pathAndId.length === 2) {
       const appID = pathAndId[1].split(' = ')
 
-      if (appID.length === 2 && !appID[1].includes('null')) {
+      if (appID.length === 2) {
         appPaths.push(pathAndId[0])
         bundleIds.push(appID[1])
       }

--- a/src/main/utils/get-installed-app-ids.ts
+++ b/src/main/utils/get-installed-app-ids.ts
@@ -1,4 +1,8 @@
-import { execSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
 
 import { sleep } from 'tings'
 
@@ -7,37 +11,115 @@ import { apps } from '../../config/apps'
 import { retrievedInstalledApps, startedScanning } from '../state/actions'
 import { dispatch } from '../state/store'
 
-function getAllInstalledBundleIds(): string[] {
-  const bundleIds = execSync(
-    'mdfind -onlyin /Applications kMDItemKind == \'*\' -attr kMDItemCFBundleIdentifier | sed -e "s/^.*kMDItemCFBundleIdentifier = //" -e "/(null)/d"',
-  )
-    .toString()
-    .trim()
-    .split('\n')
+const execFileP = promisify(execFile)
 
-  return bundleIds
+async function getAllInstalledAppBundleIds(): Promise<[string[], string[]]> {
+  const { stdout: allApps } = await execFileP('mdfind', [
+    '-onlyin',
+    '/Applications',
+    '-onlyin',
+    path.join(homedir(), 'Applications'),
+    "kMDItemKind == '*'",
+    '-attr',
+    'kMDItemCFBundleIdentifier',
+  ])
+
+  const appPaths: string[] = []
+  const bundleIds: string[] = []
+  const appsList = allApps.trim().split('\n')
+
+  for (const result of appsList) {
+    const pathAndId = result.split('   ')
+
+    if (pathAndId.length === 2) {
+      const appID = pathAndId[1].split(' = ')
+
+      if (appID.length === 2 && !appID[1].includes('null')) {
+        appPaths.push(pathAndId[0])
+        bundleIds.push(appID[1])
+      }
+    }
+  }
+
+  return [appPaths, bundleIds]
+}
+
+async function getAllInstalledApps(): Promise<string[]> {
+  const hasUserAppsFolder = fs.existsSync(path.join(homedir(), 'Applications'))
+  let findArguments: string[]
+
+  if (hasUserAppsFolder) {
+    findArguments = [
+      '/Applications',
+      path.join(homedir(), 'Applications'),
+      '-iname',
+      '*.app',
+      '-maxdepth',
+      '1',
+    ]
+  } else {
+    findArguments = ['/Applications', '-iname', '*.app', '-maxdepth', '1']
+  }
+
+  const { stdout: allApps } = await execFileP('find', findArguments)
+  const installedApps = allApps.trim().split('\n')
+
+  return installedApps
+}
+
+async function getVerifiedAppIds(): Promise<[boolean, string[]]> {
+  const [allInstalledAppPaths, allInstalledBundleIds] =
+    await getAllInstalledAppBundleIds()
+
+  const allInstalledApps = await getAllInstalledApps()
+
+  let pathsMatch = true
+
+  if (
+    allInstalledApps.length !== 0 &&
+    allInstalledApps.length === allInstalledAppPaths.length
+  ) {
+    for (const installedApp of allInstalledApps) {
+      if (!allInstalledAppPaths.includes(installedApp)) {
+        pathsMatch = false
+        break
+      }
+    }
+  } else {
+    pathsMatch = false
+  }
+
+  return [pathsMatch, allInstalledBundleIds]
 }
 
 async function getInstalledAppIds(): Promise<void> {
   dispatch(startedScanning())
+  let pathsMatch: boolean
+  let allInstalledBundleIds: string[]
 
-  const allInstalledBundleIds = getAllInstalledBundleIds()
-  const installedApps: AppId[] = []
+  // It appears that sometimes the installed app IDs are not fetched, or is incomplete.
+  // Maybe a race with Spotlight index? So to address this the app paths from 'find'
+  // are compared with the app paths from 'mdfind'. If no match, keep retrying.
+  // https://github.com/will-stone/browserosaurus/issues/572
+  for (let index = 0; index < 300; index = index + 1) {
+    // eslint-disable-next-line no-await-in-loop
+    ;[pathsMatch, allInstalledBundleIds] = await getVerifiedAppIds()
 
-  for (const installedBundleId of allInstalledBundleIds) {
-    if (installedBundleId in apps) {
-      installedApps.push(installedBundleId as AppId)
+    if (pathsMatch) {
+      const installedApps: AppId[] = []
+
+      for (const installedBundleId of allInstalledBundleIds) {
+        if (installedBundleId in apps) {
+          installedApps.push(installedBundleId as AppId)
+        }
+      }
+
+      dispatch(retrievedInstalledApps(installedApps))
+      break
+    } else {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(500)
     }
-  }
-
-  // It appears that sometimes the installed app IDs are not fetched, maybe a
-  // race with Spotlight index? So if none found, keep retrying.
-  // https://github.com/will-stone/browserosaurus/issues/425
-  if (installedApps.length === 0) {
-    await sleep(500)
-    getInstalledAppIds()
-  } else {
-    dispatch(retrievedInstalledApps(installedApps))
   }
 }
 


### PR DESCRIPTION
This PR addresses the bug report https://github.com/will-stone/browserosaurus/issues/572. It includes the following code changes from v19.3.3:

1. Add logic to compare app paths from 'find' with 'mdfind' to verify results
2. Add Node.js File System Module to verify if the user has an Applications folder
3. Replace recursion logic for getInstalledAppIds() with loop with known end state