### PR TITLE
fix: fix names for two browsers

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -105,7 +105,7 @@ const apps = typeApps({
   'Polypane': {},
   'qutebrowser': {},
   'Safari': {},
-  'Safari TP': {},
+  'Safari Technology Preview': {},
   'Sidekick': {
     privateArg: '--incognito',
   },
@@ -113,7 +113,7 @@ const apps = typeApps({
   'Sizzy': {},
   'Slack': {},
   'Spotify': {},
-  'Tor': {},
+  'Tor Browser': {},
   'Twitter': {},
   'Vivaldi': {},
   'Vivaldi Snapshot': {},


### PR DESCRIPTION
Tor Browser and Safari Technology Preview
Fixes #599