### PR TITLE
fix: suppress find errors

### DIFF
--- a/src/main/utils/get-installed-app-names.ts
+++ b/src/main/utils/get-installed-app-names.ts
@@ -10,7 +10,7 @@ import { dispatch } from '../state/store'
 
 function getAllInstalledAppNames(): string[] {
   const appNames = execSync(
-    'find /Applications -iname "*.app" -prune -not -path "*/.*"',
+    'find /Applications -iname "*.app" -prune -not -path "*/.*" 2>/dev/null',
   )
     .toString()
     .trim()


### PR DESCRIPTION
This is a small fix to address #580 whereby permission errors resulted in an incomplete browser list. This fix suppresses find errors when scanning for supported applications.