### PR TITLE
Add Drag and drop instructions to Apps pane in preferences

### DIFF
--- a/src/renderers/prefs/components/organisms/pane-apps.tsx
+++ b/src/renderers/prefs/components/organisms/pane-apps.tsx
@@ -175,6 +175,9 @@ export function AppsPane(): JSX.Element {
           </SortableContext>
         </DndContext>
       </div>
+      <p className="mt-2 text-sm opacity-70">
+        Drag and drop to sort the list of apps.
+      </p>
     </Pane>
   )
 }

--- a/src/renderers/prefs/components/organisms/pane-apps.tsx
+++ b/src/renderers/prefs/components/organisms/pane-apps.tsx
@@ -175,9 +175,11 @@ export function AppsPane(): JSX.Element {
           </SortableContext>
         </DndContext>
       </div>
-      <p className="mt-2 text-sm opacity-70">
-        Drag and drop to sort the list of apps.
-      </p>
+      {installedApps.length > 1 && (
+        <p className="mt-2 text-sm opacity-70">
+          Drag and drop to sort the list of apps.
+        </p>
+      )}
     </Pane>
   )
 }


### PR DESCRIPTION
Adds an instruction text to Apps pane in preferences fixing #620. I considered adding an icon before each app (some kind of touch target that indicates that the list items are sortable by dragging and dropping) but decided to keep the scope small.

![Screenshot 2023-02-13 at 11 09 15](https://user-images.githubusercontent.com/41864/218429785-0239fee1-d212-40b7-9037-302bcb581b80.png)
