### PR TITLE
fix: skip error from shell script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "browserosaurus",
-      "version": "20.1.0",
+      "version": "20.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "file-icon": "^5.1.1"

--- a/src/main/utils/get-installed-app-names.ts
+++ b/src/main/utils/get-installed-app-names.ts
@@ -10,7 +10,7 @@ import { dispatch } from '../state/store'
 
 function getAllInstalledAppNames(): string[] {
   const appNames = execSync(
-    'find /Applications -iname "*.app" -prune -not -path "*/.*" 2>/dev/null',
+    'find /Applications -iname "*.app" -prune -not -path "*/.*" 2>/dev/null ||true',
   )
     .toString()
     .trim()


### PR DESCRIPTION
Fixes spinning circle in V. 20.x #629 
Might be a better way though.