### PR TITLE
feat: add Orion RC browser support

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -107,6 +107,7 @@ const apps = typeApps({
   'Opera GX': {},
   'Opera Neon': {},
   'Orion': {},
+  'Orion RC': {},
   'Pocket': {
     convertUrl: (url) => `pocket://add?url=${url}`,
   },


### PR DESCRIPTION
Option for pre-release supporters to include https://browser.kagi.com/updates/orion-release-notes.html