### PR TITLE
feat: find applications in user home directory

### DIFF
--- a/src/main/utils/get-installed-app-names.ts
+++ b/src/main/utils/get-installed-app-names.ts
@@ -10,7 +10,7 @@ import { dispatch } from '../state/store'
 
 function getAllInstalledAppNames(): string[] {
   const appNames = execSync(
-    'find /Applications -iname "*.app" -prune -not -path "*/.*" 2>/dev/null ||true',
+    'find ~/Applications /Applications -iname "*.app" -prune -not -path "*/.*" 2>/dev/null ||true',
   )
     .toString()
     .trim()


### PR DESCRIPTION
Not all applications are installed at `/Applications`.  Devices where privilege access is reduced can't install apps in the root applications folder, but can install them at `~/Applications`. This is a pretty standard directory across MacOS therefore can be added as an additional directory for the `find` command

fixes: https://github.com/will-stone/browserosaurus/issues/656