### PR TITLE
fix: remove outlook protection for miro deep link

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -93,7 +93,15 @@ const apps = typeApps({
       url.replace('https://teams.microsoft.com/', 'msteams:/'),
   },
   'Min': {},
-  'Miro': {},
+  'Miro': {
+    convertUrl: (url) =>
+      decodeURIComponent(
+        url.replace(
+          /^https:\/\/[a-z]{3}[0-9]{2}\.safelinks\.protection\.outlook\.com\/\?url=https%3A%2F%2Fmiro.com/u,
+          'miroapp://miro.com',
+        ),
+      ),
+  },
   'Mullvad Browser': {
     privateArg: '--private-window',
   },


### PR DESCRIPTION
TLDR
----
This will remove the automatically ingested outlook protection link when deep linking into Miro.

More Detail
---
MS is automatically changing links in MS Teams or Outlook and prefixes them with a safety protection check. This basically destroys deep links into any application that is not a browser. I know that simply removing the link part is not a very clean solution, but by using the `miroapp` protocol handler and checking for miro.com as part of the url I think it should be ok from a security perspective.

There is maybe a more general solution for other deeplinks and/or other safety protection urls, so consider this as a first idea to address this problem.

This would solve one of my daily use-cases, but I do understand if this is considered a workaround and shouldn't go into this application.

Regards

