### PR TITLE
feat: support InPrivate browsing in Microsoft Edge

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -85,10 +85,18 @@ const apps = typeApps({
   },
   'Linear': {},
   'Maxthon': {},
-  'Microsoft Edge': {},
-  'Microsoft Edge Beta': {},
-  'Microsoft Edge Canary': {},
-  'Microsoft Edge Dev': {},
+  'Microsoft Edge': {
+    privateArg: '--inprivate',
+  },
+  'Microsoft Edge Beta': {
+    privateArg: '--inprivate',
+  },
+  'Microsoft Edge Canary': {
+    privateArg: '--inprivate',
+  },
+  'Microsoft Edge Dev': {
+    privateArg: '--inprivate',
+  },
   'Microsoft Teams': {
     convertUrl: (url) =>
       url.replace('https://teams.microsoft.com/', 'msteams:/'),


### PR DESCRIPTION
This PR allows Browserosaurus to open URLs with Microsoft Edge (along with its lesser stable release channels) in private mode.

Microsoft Edge is a decent choice on macOS, especially for someone like me who must also use Windows.