### PR TITLE
feat: add support for New and Classic Microsoft Teams

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -101,6 +101,14 @@ const apps = typeApps({
     convertUrl: (url) =>
       url.replace('https://teams.microsoft.com/', 'msteams:/'),
   },
+  'Microsoft Teams (work or school)': {
+    convertUrl: (url) =>
+      url.replace('https://teams.microsoft.com/', 'msteams:/'),
+  },
+  'Microsoft Teams classic': {
+    convertUrl: (url) =>
+      url.replace('https://teams.microsoft.com/', 'msteams:/'),
+  },
   'Min': {},
   'Miro': {},
   'Mullvad Browser': {


### PR DESCRIPTION
Microsoft renamed legacy teams and introduced a new version of teams with a new name. This will support all 3 app names, but you won't be able to choose between them with Browserosaurus, since they all use the same msteams:/ URL prefix.