### PR TITLE
feat: support InPrivate browsing in Thorium add Chromium-Gost support

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -23,6 +23,9 @@ const apps = typeApps({
   'Chromium': {
     privateArg: '--incognito',
   },
+  'Chromium-Gost': {
+    privateArg: '--incognito',
+  },
   'Discord': {
     convertUrl: (url) =>
       url.replace(
@@ -132,7 +135,9 @@ const apps = typeApps({
   'Sizzy': {},
   'Slack': {},
   'Spotify': {},
-  'Thorium': {},
+  'Thorium': {
+    privateArg: '--incognito',
+  },
   'Tor Browser': {},
   'Twitter': {},
   'Ulaa': {


### PR DESCRIPTION
Chromium-Gost a open-source fork of chromium from russia 
Thorium browser private mode was not present 