### PR TITLE
feat: add option to exit after launch

### DIFF
--- a/src/main/state/middleware.action-hub.ts
+++ b/src/main/state/middleware.action-hub.ts
@@ -134,11 +134,18 @@ export const actionHubMiddleware =
 
     // Clicked app
     else if (clickedApp.match(action)) {
-      const { appName, isAlt, isShift } = action.payload
+      const { appName, isAlt, isShift, exitMode } = action.payload
 
       // Ignore if app's bundle id is missing
       if (appName) {
-        openApp(appName, nextState.data.url, isAlt, isShift)
+        const spawn = openApp(appName, nextState.data.url, isAlt, isShift)
+        if (exitMode === 'on-launch') {
+          spawn.then(() => {
+            pickerWindow?.close()
+            prefsWindow?.close()
+            app.exit()
+          })
+        }
         pickerWindow?.hide()
       }
     }

--- a/src/main/utils/open-app.ts
+++ b/src/main/utils/open-app.ts
@@ -1,14 +1,17 @@
 import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 
 import type { AppName } from '../../config/apps.js'
 import { apps } from '../../config/apps.js'
+
+const pExecFile = promisify(execFile)
 
 export function openApp(
   appName: AppName,
   url: string,
   isAlt: boolean,
   isShift: boolean,
-): void {
+): ReturnType<typeof pExecFile> {
   const selectedApp = apps[appName]
 
   const convertedUrl =
@@ -28,5 +31,5 @@ export function openApp(
     .filter(Boolean)
     .flat()
 
-  execFile('open', openArguments)
+  return pExecFile('open', openArguments)
 }

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -30,7 +30,7 @@ async function createWindows(): Promise<void> {
     center: true,
     fullscreen: false,
     fullscreenable: false,
-    height: 500,
+    height: 600,
     maximizable: false,
     minimizable: false,
     resizable: false,

--- a/src/renderers/picker/components/layout.tsx
+++ b/src/renderers/picker/components/layout.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux'
 import { Spinner } from '../../shared/components/atoms/spinner.js'
 import {
   useDeepEqualSelector,
+  useExitMode,
   useInstalledApps,
   useKeyCodeMap,
   useSelector,
@@ -41,6 +42,7 @@ const App: React.FC = () => {
   const apps = useInstalledApps()
   const url = useSelector((state) => state.data.url)
   const icons = useDeepEqualSelector((state) => state.data.icons)
+  const exitMode = useExitMode()
 
   const keyCodeMap = useKeyCodeMap()
 
@@ -87,6 +89,7 @@ const App: React.FC = () => {
                   dispatch(
                     clickedApp({
                       appName: app.name,
+                      exitMode,
                       isAlt: event.altKey,
                       isShift: event.shiftKey,
                     }),

--- a/src/renderers/picker/components/organisms/apps.test.tsx
+++ b/src/renderers/picker/components/organisms/apps.test.tsx
@@ -77,6 +77,7 @@ test('kitchen sink', async () => {
             name: 'Brave Browser',
           },
         ],
+        exitMode: 'none',
         height: 200,
         isSetup: true,
         supportMessage: -1,
@@ -95,6 +96,7 @@ test('kitchen sink', async () => {
     addChannelToAction(
       clickedApp({
         appName: 'Firefox',
+        exitMode: 'none',
         isAlt: false,
         isShift: false,
       }),
@@ -113,6 +115,7 @@ test('kitchen sink', async () => {
     addChannelToAction(
       clickedApp({
         appName: 'Brave Browser',
+        exitMode: 'none',
         isAlt: true,
         isShift: false,
       }),
@@ -136,6 +139,7 @@ test('should show spinner when no installed apps are found', async () => {
             name: 'Safari',
           },
         ],
+        exitMode: 'none',
         height: 200,
         isSetup: true,
         supportMessage: -1,
@@ -161,6 +165,7 @@ test('should use hotkey', async () => {
             name: 'Safari',
           },
         ],
+        exitMode: 'none',
         height: 200,
         isSetup: true,
         supportMessage: -1,
@@ -203,6 +208,7 @@ test('should use hotkey with alt', async () => {
             name: 'Safari',
           },
         ],
+        exitMode: 'none',
         height: 200,
         isSetup: true,
         supportMessage: -1,
@@ -246,6 +252,7 @@ test('should hold shift', async () => {
     addChannelToAction(
       clickedApp({
         appName: 'Firefox',
+        exitMode: 'none',
         isAlt: false,
         isShift: true,
       }),
@@ -265,6 +272,7 @@ test('should order tiles', async () => {
       data: defaultData,
       storage: {
         apps: [],
+        exitMode: 'none',
         height: 200,
         isSetup: true,
         supportMessage: -1,

--- a/src/renderers/picker/state/actions.ts
+++ b/src/renderers/picker/state/actions.ts
@@ -7,6 +7,7 @@ type OpenAppArguments = {
   appName: AppName | undefined
   isAlt: boolean
   isShift: boolean
+  exitMode: 'none' | 'on-launch'
 }
 
 const startedPicker = picker('started')

--- a/src/renderers/prefs/components/organisms/pane-general.tsx
+++ b/src/renderers/prefs/components/organisms/pane-general.tsx
@@ -1,8 +1,9 @@
 import { useDispatch } from 'react-redux'
 
 import Button from '../../../shared/components/atoms/button.js'
-import { useSelector } from '../../../shared/state/hooks.js'
+import { useExitMode, useSelector } from '../../../shared/state/hooks.js'
 import {
+  changedExitMode,
   clickedRescanApps,
   clickedSetAsDefaultBrowserButton,
   clickedUpdateButton,
@@ -43,6 +44,7 @@ export const GeneralPane = (): JSX.Element => {
   )
 
   const updateStatus = useSelector((state) => state.data.updateStatus)
+  const exitMode = useExitMode()
 
   const numberOfInstalledApps = useSelector(
     (state) => state.storage.apps.filter((app) => app.isInstalled).length,
@@ -116,6 +118,28 @@ export const GeneralPane = (): JSX.Element => {
           <p className="mt-2 text-sm opacity-70">
             Restores all preferences to initial defaults and restarts the app as
             if run for the first time.
+          </p>
+        </Right>
+      </Row>
+
+      <Row>
+        <Left>Exit on selection:</Left>
+        <Right>
+          <input
+            checked={exitMode === 'on-launch' ? true : undefined}
+            onChange={(ev) => {
+              const isChecked = ev.target.checked
+              if (isChecked) {
+                dispatch(changedExitMode('on-launch'))
+              } else {
+                dispatch(changedExitMode('none'))
+              }
+            }}
+            type="checkbox"
+          />
+          <p className="mt-2 text-sm opacity-70">
+            Exiting Browserosaurus after selecting a browser can reduce memory
+            usage and fix issues when using fullscreen apps.
           </p>
         </Right>
       </Row>

--- a/src/renderers/prefs/state/actions.ts
+++ b/src/renderers/prefs/state/actions.ts
@@ -28,7 +28,10 @@ const reorderedApp = prefs<{ sourceName: AppName; destinationName: AppName }>(
 const clickedHomepageButton = prefs('homepage-button/clicked')
 const clickedOpenIssueButton = prefs('open-issue-button/clicked')
 
+const changedExitMode = prefs<'none' | 'on-launch'>('exit-mode/changed')
+
 export {
+  changedExitMode,
   clickedHomepageButton,
   clickedOpenIssueButton,
   clickedRescanApps,

--- a/src/renderers/shared/state/hooks.ts
+++ b/src/renderers/shared/state/hooks.ts
@@ -46,9 +46,13 @@ const useIsSupportMessageHidden = (): boolean => {
 const useKeyCodeMap = (): Record<string, string> =>
   useShallowEqualSelector((state) => state.data.keyCodeMap)
 
+const useExitMode = (): 'none' | 'on-launch' =>
+  useShallowEqualSelector((state) => state.storage.exitMode)
+
 export {
   InstalledApp,
   useDeepEqualSelector,
+  useExitMode,
   useInstalledApps,
   useIsSupportMessageHidden,
   useKeyCodeMap,

--- a/src/shared/state/reducer.storage.ts
+++ b/src/shared/state/reducer.storage.ts
@@ -12,6 +12,7 @@ import {
   clickedMaybeLater,
 } from '../../renderers/picker/state/actions.js'
 import {
+  changedExitMode,
   confirmedReset,
   reorderedApp,
   updatedHotCode,
@@ -26,10 +27,12 @@ type Storage = {
   supportMessage: number
   isSetup: boolean
   height: number
+  exitMode: 'none' | 'on-launch'
 }
 
 const defaultStorage: Storage = {
   apps: [],
+  exitMode: 'none',
   height: 200,
   isSetup: false,
   supportMessage: 0,
@@ -111,6 +114,10 @@ const storage = createReducer<Storage>(defaultStorage, (builder) =>
 
       const [removed] = state.apps.splice(sourceIndex, 1)
       state.apps.splice(destinationIndex, 0, removed)
+    })
+
+    .addCase(changedExitMode, (state, action) => {
+      state.exitMode = action.payload
     }),
 )
 


### PR DESCRIPTION
Using this option fixes #595 by proxy of spawning a new instance on the current desktop.

I imagine cleaning up Browserosaurus can also help conserve memory usage on those systems with little of it, at the cost of startup time.

Keep in mind if this option is set during development, Browserosaurus *will* exit and you'll have to restart it on the command line to use it as the default HTTP handler; but in production this would seamlessly spin up the app when the user clicks a link.

This returns a promise from `openApp` which could perhaps be used for more extensive error handling in the future.