### PR TITLE
feat: add support for PrivateWindow and PublicWindow browser apps

### DIFF
--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -135,6 +135,8 @@ const apps = typeApps({
     convertUrl: (url) => `pocket://add?url=${url}`,
   },
   Polypane: {},
+  'PrivateWindow': {},
+  'PublicWindow': {},
   qutebrowser: {},
   Safari: {},
   'Safari Technology Preview': {},


### PR DESCRIPTION
Adds support for the PrivateWindow and PublicWindow browser apps from [https://github.com/lapcat/PrivateWindow](https://github.com/lapcat/PrivateWindow). I find these apps useful for explicitly opening a link in Safari using a Private window or a normal window. 